### PR TITLE
Adding empty string check to method registerPathsAndRoles in case the…

### DIFF
--- a/src/main/java/gov/cdc/izgateway/security/AccessControlRegistry.java
+++ b/src/main/java/gov/cdc/izgateway/security/AccessControlRegistry.java
@@ -121,7 +121,7 @@ public class AccessControlRegistry implements IAccessControlRegistry {
 	 * @param mapping	Request Mappings associated with the method or class.
 	 */
 	private void registerPathsAndRoles(String prefix, RolesAllowed roles, MergedAnnotation<RequestMapping> mapping, boolean add) {
-		if (prefix != null && !prefix.endsWith("/")) {
+		if (prefix != null && !prefix.isEmpty() && !prefix.endsWith("/")) {
 			prefix += "/";
 		}
 		if (mapping == null) {


### PR DESCRIPTION
… prefix happens to be empty.  This was causing a double slash to be registered for the method.  This change fixes that.