### PR TITLE
IGDD-1417 - JWT principal updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
        release branch is labeled <major>.<minor>.<patch>-izgw-core-SNAPSHOT 
        main branch is labeled <major>.<minor>.<patch>-izgw-core-RELEASE 
   -->
-  <version>2.1.7-izgw-core-austin-SNAPSHOT</version>
+  <version>2.1.8-izgw-core-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>IZ Gateway Core 2.1.7</name>
+  <name>IZ Gateway Core 2.1.8 </name>
   <description>IZ Gateway Core contains the core code for the IZ Gateway Hub and Transformation services</description>
   <distributionManagement>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
        release branch is labeled <major>.<minor>.<patch>-izgw-core-SNAPSHOT 
        main branch is labeled <major>.<minor>.<patch>-izgw-core-RELEASE 
   -->
-  <version>2.1.7-izgw-core-SNAPSHOT</version>
+  <version>2.1.7-izgw-core-austin-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>IZ Gateway Core 2.1.7</name>
   <description>IZ Gateway Core contains the core code for the IZ Gateway Hub and Transformation services</description>

--- a/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
+++ b/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
@@ -1,10 +1,44 @@
 package gov.cdc.izgateway.security;
 
+import gov.cdc.izgateway.security.principal.GroupToRoleMapper;
+import gov.cdc.izgateway.security.principal.ScopeToRoleMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
+import java.util.*;
 
+@Slf4j
+@Component
 public class JWTPrincipal extends IzgPrincipal {
+
+    private final GroupToRoleMapper groupToRoleMapper;
+    private final ScopeToRoleMapper scopeToRoleMapper;
+
+    public JWTPrincipal(Jwt jwt,
+                        GroupToRoleMapper groupToRoleMapper,
+                        ScopeToRoleMapper scopeToRoleMapper,
+                        String rolesClaim,
+                        String scopesClaim) {
+        this.groupToRoleMapper = groupToRoleMapper;
+        this.scopeToRoleMapper = scopeToRoleMapper;
+
+        setName(jwt.getSubject());
+        setOrganization(getClaimNestedAsString(jwt, "organization"));
+        setValidFrom(Date.from(Objects.requireNonNull(jwt.getIssuedAt())));
+        setValidTo(Date.from(Objects.requireNonNull(jwt.getExpiresAt())));
+        setSerialNumber(jwt.getId());
+        // Nimbus doesn't like non-URI issuers, pull via raw claim
+        setIssuer(getClaimNestedAsString(jwt, "iss"));
+        setAudience(jwt.getAudience());
+        addScopes(getClaimNested(jwt, scopesClaim));
+        addRolesFromScopes(getClaimNested(jwt, scopesClaim));
+        addRolesFromGroups(getClaimNested(jwt, rolesClaim));
+    }
 
     public String getSerialNumberHex() {
         // If isNumeric, return the hex representation
@@ -29,5 +63,97 @@ public class JWTPrincipal extends IzgPrincipal {
         } catch (IllegalArgumentException ex) {
             return false;
         }
+    }
+
+    private void addScopes(Object scopesClaim) {
+        TreeSet<String> scopes = extractClaimList(scopesClaim);
+        setScopes(scopes);
+    }
+
+    private void addRolesFromScopes(Object scopesClaim) {
+        if (scopeToRoleMapper == null) {
+            log.debug("No scope to role mapper was set. Skipping scope to role mapping.");
+            return;
+        }
+        TreeSet<String> scopes = extractClaimList(scopesClaim);
+        getRoles()
+                .addAll(
+                        scopeToRoleMapper.mapScopesToRoles(scopes)
+                );
+    }
+
+    private TreeSet<String> extractClaimList(Object scopeList) {
+        // Oauth2 RFC (https://www.rfc-editor.org/rfc/rfc6749) states scopes
+        // should be "expressed as a list of space-delimited, case-sensitive strings"
+        // However, Okta seems to send back an array of strings.
+        TreeSet<String> scopes = new TreeSet<>();
+        if (scopeList instanceof String scopeString) {
+            if (!StringUtils.isEmpty(scopeString)) {
+                Collections.addAll(scopes, scopeString.split(" "));
+            }
+        } else if (scopeList instanceof Collection<?> collection) {
+            collection.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .forEach(scopes::add);
+        }
+        return scopes;
+    }
+
+    private void addRolesFromGroups(Object groupsClaim) {
+        if (groupToRoleMapper == null) {
+            log.debug("No group to role mapper was set. Skipping group to role mapping.");
+            return;
+        }
+
+        TreeSet<String> groupsList = extractClaimList(groupsClaim);
+        if (groupsList.isEmpty()) {
+            return;
+        }
+
+        getRoles()
+                .addAll(
+                        groupToRoleMapper.mapGroupsToRoles(groupsList)
+                );
+    }
+
+    private String getClaimNestedAsString(Jwt jwt, String claimName) {
+        Object claimValue = getClaimNested(jwt, claimName);
+        return claimValue != null ? claimValue.toString() : null;
+    }
+
+    private Object getClaimNested(Jwt jwt, String claimPath) {
+        String[] claimPathParts = claimPath.split("\\.");
+        Object claim = jwt.getClaim(claimPathParts[0]);
+
+        if (claimPathParts.length > 1 && !(claim instanceof Map<?,?>)) {
+            /*
+             Catches situation where you have configured groups.access.
+             The initial pull of groups returns an array list.
+             Without this, we'd end up returning that pull from groups
+             as the claim Object, and ignore the fact that the user had
+             configured another level.
+             Seemed dangerous.
+            */
+            return null;
+        }
+
+        if (claim instanceof Map<?, ?> map && claimPathParts.length > 1) {
+            for (int i = 1; i < claimPathParts.length; i++) {
+                claim = map.get(claimPathParts[i]);
+                if (claim instanceof Map<?, ?>) {
+                    map = (Map<?, ?>) claim;
+                } else if (i < claimPathParts.length - 1) {
+                    /*
+                    Again, catches a situation where the user has configured groups.level1.level2 and at level1
+                    we have gotten a non-Map.
+                    So basically level2 didn't exist, but we don't want to return
+                    the value pulled from level1.
+                     */
+                    return null;
+                }
+            }
+        }
+        return claim;
     }
 }

--- a/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
+++ b/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
@@ -4,6 +4,7 @@ import gov.cdc.izgateway.security.principal.GroupToRoleMapper;
 import gov.cdc.izgateway.security.principal.ScopeToRoleMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
@@ -19,10 +20,10 @@ public class JWTPrincipal extends IzgPrincipal {
     private final ScopeToRoleMapper scopeToRoleMapper;
 
     public JWTPrincipal(Jwt jwt,
-                        GroupToRoleMapper groupToRoleMapper,
-                        ScopeToRoleMapper scopeToRoleMapper,
                         String rolesClaim,
-                        String scopesClaim) {
+                        String scopesClaim,
+                        @Nullable GroupToRoleMapper groupToRoleMapper,
+                        @Nullable ScopeToRoleMapper scopeToRoleMapper) {
         this.groupToRoleMapper = groupToRoleMapper;
         this.scopeToRoleMapper = scopeToRoleMapper;
 

--- a/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
+++ b/src/main/java/gov/cdc/izgateway/security/JWTPrincipal.java
@@ -4,7 +4,6 @@ import gov.cdc.izgateway.security.principal.GroupToRoleMapper;
 import gov.cdc.izgateway.security.principal.ScopeToRoleMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
@@ -1,5 +1,7 @@
 package gov.cdc.izgateway.security.principal;
 
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
 import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
 import gov.cdc.izgateway.security.IzgPrincipal;
 import gov.cdc.izgateway.security.JWTPrincipal;
@@ -8,9 +10,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.*;
 
-import java.util.Objects;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Map;
 
 @Slf4j
 public abstract class AbstractJwtPrincipalProvider implements JwtPrincipalProvider {
@@ -35,14 +42,75 @@ public abstract class AbstractJwtPrincipalProvider implements JwtPrincipalProvid
     }
 
     protected abstract NimbusJwtDecoder createDecoder();
+
     protected abstract boolean validConfiguration();
 
     protected DelegatingOAuth2TokenValidator<Jwt> createValidator() {
         JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
+
+        // Validator for 'exp' presence - required
+        OAuth2TokenValidator<Jwt> expPresenceValidator = token -> {
+            if (!token.getClaims().containsKey("exp")) {
+                return OAuth2TokenValidatorResult.failure(
+                        new OAuth2Error("invalid_token", "Token must contain exp claim", null)
+                );
+            }
+            return OAuth2TokenValidatorResult.success();
+        };
+
+        // Custom validator for 'iat' OR 'nbf' presence in raw payload
+        OAuth2TokenValidator<Jwt> timeConstraintValidator = token -> {
+            try {
+                SignedJWT signedJWT = (SignedJWT) JWTParser.parse(token.getTokenValue());
+                Map<String, Object> rawClaims = signedJWT.getJWTClaimsSet().getClaims();
+
+                boolean hasIat = rawClaims.containsKey("iat");
+                boolean hasNbf = rawClaims.containsKey("nbf");
+
+                if (!hasIat && !hasNbf) {
+                    return OAuth2TokenValidatorResult.failure(
+                            new OAuth2Error("invalid_token",
+                                    "Token must contain either iat or nbf claim", null)
+                    );
+                }
+            } catch (ParseException e) {
+                return OAuth2TokenValidatorResult.failure(
+                        new OAuth2Error("invalid_token", "Failed to parse claims from JWT", null)
+                );
+            }
+            return OAuth2TokenValidatorResult.success();
+        };
+
+        OAuth2TokenValidator<Jwt> futureIatCheck = token -> {
+            try {
+                SignedJWT signedJWT = (SignedJWT) JWTParser.parse(token.getTokenValue());
+                Map<String, Object> rawClaims = signedJWT.getJWTClaimsSet().getClaims();
+
+                boolean hasIat = rawClaims.containsKey("iat");
+
+                if (hasIat) {
+                    // check to see if iat is in the future
+                    Instant iat = token.getIssuedAt();
+                    if ((iat != null) && iat.isAfter(Instant.now())) {
+                        return OAuth2TokenValidatorResult.failure(
+                                new OAuth2Error("invalid_token", "iat cannot be in the future", null)
+                        );
+                    }
+                }
+            } catch (ParseException e) {
+                return OAuth2TokenValidatorResult.failure(
+                        new OAuth2Error("invalid_token", "Failed to parse claims from JWT", null)
+                );
+            }
+            return OAuth2TokenValidatorResult.success();
+        };
+
+
         return new DelegatingOAuth2TokenValidator<>(
                 timestampValidator,
-                new JwtClaimValidator<>(JwtClaimNames.EXP, Objects::nonNull),
-                new JwtClaimValidator<>(JwtClaimNames.IAT, Objects::nonNull)
+                expPresenceValidator,
+                timeConstraintValidator,
+                futureIatCheck
         );
     }
 
@@ -70,9 +138,10 @@ public abstract class AbstractJwtPrincipalProvider implements JwtPrincipalProvid
             );
 
         } catch (InvalidJwtTokenException e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
             return null;
         } catch (Exception e) {
-            log.warn("Issue processing JWT token", e);
+            log.warn("Issue processing JWT token: {}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
@@ -1,0 +1,79 @@
+package gov.cdc.izgateway.security.principal;
+
+import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
+import gov.cdc.izgateway.security.IzgPrincipal;
+import gov.cdc.izgateway.security.JWTPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.*;
+
+import java.util.Objects;
+
+@Slf4j
+public abstract class AbstractJwtPrincipalProvider implements JwtPrincipalProvider {
+
+    @Value("${jwt.roles-claim}")
+    private String rolesClaim;
+
+    @Value("${jwt.scopes-claim}")
+    private String scopesClaim;
+
+    protected final GroupToRoleMapper groupToRoleMapper;
+    protected final ScopeToRoleMapper scopeToRoleMapper;
+    protected final JwtTokenExtractor jwtTokenExtractor;
+
+    protected AbstractJwtPrincipalProvider(
+            @Nullable GroupToRoleMapper groupToRoleMapper,
+            @Nullable ScopeToRoleMapper scopeToRoleMapper,
+            JwtTokenExtractor jwtTokenExtractor) {
+        this.groupToRoleMapper = groupToRoleMapper;
+        this.scopeToRoleMapper = scopeToRoleMapper;
+        this.jwtTokenExtractor = jwtTokenExtractor;
+    }
+
+    protected abstract NimbusJwtDecoder createDecoder();
+    protected abstract boolean validConfiguration();
+
+    protected DelegatingOAuth2TokenValidator<Jwt> createValidator() {
+        JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
+        return new DelegatingOAuth2TokenValidator<>(
+                timestampValidator,
+                new JwtClaimValidator<>(JwtClaimNames.EXP, Objects::nonNull),
+                new JwtClaimValidator<>(JwtClaimNames.IAT, Objects::nonNull)
+        );
+    }
+
+    @Override
+    public IzgPrincipal createPrincipalFromJwt(HttpServletRequest request) {
+        if (!validConfiguration()) {
+            return null;
+        }
+
+        try {
+            String token = jwtTokenExtractor.extractToken(request);
+
+            NimbusJwtDecoder jwtDecoder = createDecoder();
+            jwtDecoder.setJwtValidator(createValidator());
+
+            Jwt jwt = jwtDecoder.decode(token);
+
+            log.debug("JWT claims for current request: {}", jwt.getClaims());
+
+            return new JWTPrincipal(jwt,
+                    groupToRoleMapper,
+                    scopeToRoleMapper,
+                    rolesClaim,
+                    scopesClaim
+            );
+
+        } catch (InvalidJwtTokenException e) {
+            return null;
+        } catch (Exception e) {
+            log.warn("Issue processing JWT token", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProvider.java
@@ -63,10 +63,10 @@ public abstract class AbstractJwtPrincipalProvider implements JwtPrincipalProvid
             log.debug("JWT claims for current request: {}", jwt.getClaims());
 
             return new JWTPrincipal(jwt,
-                    groupToRoleMapper,
-                    scopeToRoleMapper,
                     rolesClaim,
-                    scopesClaim
+                    scopesClaim,
+                    groupToRoleMapper,
+                    scopeToRoleMapper
             );
 
         } catch (InvalidJwtTokenException e) {

--- a/src/main/java/gov/cdc/izgateway/security/principal/InvalidJwtTokenException.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/InvalidJwtTokenException.java
@@ -1,0 +1,11 @@
+package gov.cdc.izgateway.security.principal;
+
+public class InvalidJwtTokenException extends RuntimeException {
+    public InvalidJwtTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidJwtTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/security/principal/InvalidJwtTokenException.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/InvalidJwtTokenException.java
@@ -4,8 +4,4 @@ public class InvalidJwtTokenException extends RuntimeException {
     public InvalidJwtTokenException(String message) {
         super(message);
     }
-
-    public InvalidJwtTokenException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
@@ -21,8 +21,8 @@ public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
     @Value("${jwt.jwk-set-uri:}")
     private String jwkSetUri;
 
-    @Value("${jwt.user-permissions-claim}")
-    private String userPermissionsClaim;
+    @Value("${jwt.roles-claim}")
+    private String rolesClaim;
 
     @Value("${jwt.scopes-claim}")
     private String scopesClaim;
@@ -64,7 +64,7 @@ public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
             return null;
         }
 
-        IzgPrincipal principal = new JWTPrincipal();
+        IzgPrincipal principal = new JWTPrincipal(jwt, groupToRoleMapper, scopeToRoleMapper, rolesClaim, scopesClaim);
         principal.setName(jwt.getSubject());
         principal.setOrganization(getClaimNestedAsString(jwt, "organization"));
         principal.setValidFrom(Date.from(Objects.requireNonNull(jwt.getIssuedAt())));
@@ -75,7 +75,7 @@ public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
         principal.setAudience(jwt.getAudience());
         addScopes(getClaimNested(jwt, scopesClaim), principal);
         addRolesFromScopes(getClaimNested(jwt, scopesClaim), principal);
-        addRolesFromGroups(getClaimNested(jwt, userPermissionsClaim), principal);
+        addRolesFromGroups(getClaimNested(jwt, rolesClaim), principal);
         log.debug("JWT claims for current request: {}", jwt.getClaims());
         return principal;
     }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
@@ -8,12 +8,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.*;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -29,11 +28,14 @@ public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
 
     private final GroupToRoleMapper groupToRoleMapper;
     private final ScopeToRoleMapper scopeToRoleMapper;
+    private final JwtTokenExtractor jwtTokenExtractor;
 
     public JwtJwksPrincipalProvider(@Nullable GroupToRoleMapper groupToRoleMapper,
-                                    @Nullable ScopeToRoleMapper scopeToRoleMapper) {
+                                    @Nullable ScopeToRoleMapper scopeToRoleMapper,
+                                    JwtTokenExtractor jwtTokenExtractor) {
         this.groupToRoleMapper = groupToRoleMapper;
         this.scopeToRoleMapper = scopeToRoleMapper;
+        this.jwtTokenExtractor = jwtTokenExtractor;
     }
 
 
@@ -44,133 +46,39 @@ public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
             return null;
         }
 
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            log.debug("No JWT token found in Authorization header");
-            return null;
-        }
-
-        JwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
-
-        Jwt jwt;
-
         try {
-            String token = authHeader.substring(7);
-            jwt = jwtDecoder.decode(token);
+            String token = jwtTokenExtractor.extractToken(request);
 
+            // We do not want to accept JWT tokens without From/To dates
+            JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
+            DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
+                    timestampValidator,
+                    new JwtClaimValidator<>(JwtClaimNames.EXP, Objects::nonNull),
+                    new JwtClaimValidator<>(JwtClaimNames.IAT, Objects::nonNull)
+            );
 
+            NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
+                    .withJwkSetUri(jwkSetUri)
+                    .build();
+            jwtDecoder.setJwtValidator(validator);
+
+            Jwt jwt = jwtDecoder.decode(token);
+
+            log.debug("JWT claims for current request: {}", jwt.getClaims());
+
+            return new JWTPrincipal(jwt,
+                    groupToRoleMapper,
+                    scopeToRoleMapper,
+                    rolesClaim,
+                    scopesClaim
+            );
+
+        } catch (InvalidJwtTokenException e) {
+            return null;
         } catch (Exception e) {
-            log.warn("Error parsing JWT token", e);
+            log.warn("Issue processing JWT token", e);
             return null;
         }
 
-        IzgPrincipal principal = new JWTPrincipal(jwt, groupToRoleMapper, scopeToRoleMapper, rolesClaim, scopesClaim);
-        principal.setName(jwt.getSubject());
-        principal.setOrganization(getClaimNestedAsString(jwt, "organization"));
-        principal.setValidFrom(Date.from(Objects.requireNonNull(jwt.getIssuedAt())));
-        principal.setValidTo(Date.from(Objects.requireNonNull(jwt.getExpiresAt())));
-        principal.setSerialNumber(jwt.getId());
-        // Nimbus doesn't like non-URI issuers, pull via raw claim
-        principal.setIssuer(getClaimNestedAsString(jwt, "iss"));
-        principal.setAudience(jwt.getAudience());
-        addScopes(getClaimNested(jwt, scopesClaim), principal);
-        addRolesFromScopes(getClaimNested(jwt, scopesClaim), principal);
-        addRolesFromGroups(getClaimNested(jwt, rolesClaim), principal);
-        log.debug("JWT claims for current request: {}", jwt.getClaims());
-        return principal;
-    }
-
-    private void addScopes(Object scopesClaim, IzgPrincipal principal) {
-        TreeSet<String> scopes = extractClaimList(scopesClaim);
-        principal.setScopes(scopes);
-    }
-
-    private void addRolesFromScopes(Object scopesClaim, IzgPrincipal principal) {
-        if (scopeToRoleMapper == null) {
-            log.debug("No scope to role mapper was set. Skipping scope to role mapping.");
-            return;
-        }
-        TreeSet<String> scopes = extractClaimList(scopesClaim);
-        principal
-                .getRoles()
-                .addAll(
-                        scopeToRoleMapper.mapScopesToRoles(scopes)
-                );
-    }
-
-    private TreeSet<String> extractClaimList(Object scopeList) {
-        // Oauth2 RFC (https://www.rfc-editor.org/rfc/rfc6749) states scopes
-        // should be "expressed as a list of space-
-        //   delimited, case-sensitive strings"
-        // However Okta seems to send back array of strings.
-        TreeSet<String> scopes = new TreeSet<>();
-        if (scopeList instanceof String scopeString) {
-            if (!StringUtils.isEmpty(scopeString)) {
-                Collections.addAll(scopes, scopeString.split(" "));
-            }
-        } else if (scopeList instanceof Collection<?> collection) {
-            collection.stream()
-                    .filter(String.class::isInstance)
-                    .map(String.class::cast)
-                    .forEach(scopes::add);
-        }
-        return scopes;
-    }
-
-    private void addRolesFromGroups(Object groupsClaim, IzgPrincipal principal) {
-        if (groupToRoleMapper == null) {
-            log.debug("No group to role mapper was set. Skipping group to role mapping.");
-            return;
-        }
-
-        TreeSet<String> groupsList = extractClaimList(groupsClaim);
-        if (groupsList.isEmpty()) {
-            return;
-        }
-
-        principal
-                .getRoles()
-                .addAll(
-                        groupToRoleMapper.mapGroupsToRoles(groupsList)
-                );
-    }
-
-    private String getClaimNestedAsString(Jwt jwt, String claimName) {
-        Object claimValue = getClaimNested(jwt, claimName);
-        return claimValue != null ? claimValue.toString() : null;
-    }
-
-    private Object getClaimNested(Jwt jwt, String claimPath) {
-        String[] claimPathParts = claimPath.split("\\.");
-        Object claim = jwt.getClaim(claimPathParts[0]);
-
-        if (claimPathParts.length > 1 && !(claim instanceof Map<?,?>)) {
-            /*
-             Catches situation where you have configured groups.access.
-             The initial pull of groups returns an array list.
-             Without this, we'd end up returning that pull from groups
-             as the claim Object, and ignore the fact that the user had
-             configured another level.
-             Seemed dangerous.
-            */
-            return null;
-        }
-
-        if (claim instanceof Map<?, ?> map && claimPathParts.length > 1) {
-            for (int i = 1; i < claimPathParts.length; i++) {
-                claim = map.get(claimPathParts[i]);
-                if (claim instanceof Map<?, ?>) {
-                    map = (Map<?, ?>) claim;
-                } else if (i < claimPathParts.length - 1) {
-                    /*
-                    Again, catches a situation where the user has configured groups.level1.level2 and at level1
-                    we have obtained a non-Map. So basically level2 didn't exist, but we don't want to return
-                    the value pulled from level1.
-                     */
-                    return null;
-                }
-            }
-        }
-        return claim;
     }
 }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtJwksPrincipalProvider.java
@@ -1,84 +1,38 @@
 package gov.cdc.izgateway.security.principal;
 
-import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
-import gov.cdc.izgateway.security.IzgPrincipal;
-import gov.cdc.izgateway.security.JWTPrincipal;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
-
 @Slf4j
 @Component
-public class JwtJwksPrincipalProvider implements JwtPrincipalProvider {
+public class JwtJwksPrincipalProvider extends AbstractJwtPrincipalProvider {
     @Value("${jwt.jwk-set-uri:}")
     private String jwkSetUri;
-
-    @Value("${jwt.roles-claim}")
-    private String rolesClaim;
-
-    @Value("${jwt.scopes-claim}")
-    private String scopesClaim;
-
-    private final GroupToRoleMapper groupToRoleMapper;
-    private final ScopeToRoleMapper scopeToRoleMapper;
-    private final JwtTokenExtractor jwtTokenExtractor;
 
     public JwtJwksPrincipalProvider(@Nullable GroupToRoleMapper groupToRoleMapper,
                                     @Nullable ScopeToRoleMapper scopeToRoleMapper,
                                     JwtTokenExtractor jwtTokenExtractor) {
-        this.groupToRoleMapper = groupToRoleMapper;
-        this.scopeToRoleMapper = scopeToRoleMapper;
-        this.jwtTokenExtractor = jwtTokenExtractor;
+        super(groupToRoleMapper, scopeToRoleMapper, jwtTokenExtractor);
     }
 
+    @Override
+    protected NimbusJwtDecoder createDecoder() {
+        return NimbusJwtDecoder
+                .withJwkSetUri(jwkSetUri)
+                .build();
+    }
 
     @Override
-    public IzgPrincipal createPrincipalFromJwt(HttpServletRequest request) {
-        if (StringUtils.isBlank(jwkSetUri)) {
-            log.warn("No JWT set URI configured.  JWT authentication is disabled.");
-            return null;
+    protected boolean validConfiguration() {
+        if (StringUtils.isNotBlank(jwkSetUri)) {
+            return true;
         }
 
-        try {
-            String token = jwtTokenExtractor.extractToken(request);
-
-            // We do not want to accept JWT tokens without From/To dates
-            JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
-            DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
-                    timestampValidator,
-                    new JwtClaimValidator<>(JwtClaimNames.EXP, Objects::nonNull),
-                    new JwtClaimValidator<>(JwtClaimNames.IAT, Objects::nonNull)
-            );
-
-            NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
-                    .withJwkSetUri(jwkSetUri)
-                    .build();
-            jwtDecoder.setJwtValidator(validator);
-
-            Jwt jwt = jwtDecoder.decode(token);
-
-            log.debug("JWT claims for current request: {}", jwt.getClaims());
-
-            return new JWTPrincipal(jwt,
-                    groupToRoleMapper,
-                    scopeToRoleMapper,
-                    rolesClaim,
-                    scopesClaim
-            );
-
-        } catch (InvalidJwtTokenException e) {
-            return null;
-        } catch (Exception e) {
-            log.warn("Issue processing JWT token", e);
-            return null;
-        }
-
+        log.warn("No JWT set URI configured.  JWT authentication is disabled.");
+        return false;
     }
 }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtPrincipalProviderConfig.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtPrincipalProviderConfig.java
@@ -3,11 +3,9 @@ package gov.cdc.izgateway.security.principal;
 import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan("gov.cdc.izgateway.security.principal")
 public class JwtPrincipalProviderConfig {
     @Value("${jwt.provider:shared-secret}")
     private String jwtProvider;

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtPrincipalProviderConfig.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtPrincipalProviderConfig.java
@@ -3,9 +3,11 @@ package gov.cdc.izgateway.security.principal;
 import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ComponentScan("gov.cdc.izgateway.security.principal")
 public class JwtPrincipalProviderConfig {
     @Value("${jwt.provider:shared-secret}")
     private String jwtProvider;

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtSharedSecretPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtSharedSecretPrincipalProvider.java
@@ -1,90 +1,44 @@
 package gov.cdc.izgateway.security.principal;
 
-import gov.cdc.izgateway.principal.provider.JwtPrincipalProvider;
-import gov.cdc.izgateway.security.IzgPrincipal;
-import gov.cdc.izgateway.security.JWTPrincipal;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.spec.SecretKeySpec;
-import java.util.*;
 
 @Slf4j
 @Component
-public class JwtSharedSecretPrincipalProvider implements JwtPrincipalProvider {
+public class JwtSharedSecretPrincipalProvider extends AbstractJwtPrincipalProvider {
     @Value("${jwt.shared-secret:}")
     private String sharedSecret;
-
-    @Value("${jwt.roles-claim}")
-    private String rolesClaim;
-
-    @Value("${jwt.scopes-claim}")
-    private String scopesClaim;
-
-    private final GroupToRoleMapper groupToRoleMapper;
-    private final ScopeToRoleMapper scopeToRoleMapper;
-    private final JwtTokenExtractor jwtTokenExtractor;
 
     @Autowired
     public JwtSharedSecretPrincipalProvider(@Nullable GroupToRoleMapper groupToRoleMapper,
                                             @Nullable ScopeToRoleMapper scopeToRoleMapper,
                                             JwtTokenExtractor jwtTokenExtractor) {
-        this.groupToRoleMapper = groupToRoleMapper;
-        this.scopeToRoleMapper = scopeToRoleMapper;
-        this.jwtTokenExtractor = jwtTokenExtractor;
+        super(groupToRoleMapper, scopeToRoleMapper, jwtTokenExtractor);
     }
 
     @Override
-    public IzgPrincipal createPrincipalFromJwt(HttpServletRequest request) {
-        if (StringUtils.isBlank(sharedSecret)) {
-            log.warn("No JWT shared secret was set. JWT authentication is disabled.");
-            return null;
-        }
-
+    protected NimbusJwtDecoder createDecoder() {
         SecretKeySpec secretKey = new SecretKeySpec(sharedSecret.getBytes(), "HmacSHA256");
+        return NimbusJwtDecoder
+                .withSecretKey(secretKey)
+                .build();
+    }
 
-        try {
-            String token = jwtTokenExtractor.extractToken(request);
-
-            // We do not want to accept JWT tokens without From/To dates
-            JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
-            DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
-                    timestampValidator,
-                    new JwtClaimValidator<>(JwtClaimNames.EXP, Objects::nonNull),
-                    new JwtClaimValidator<>(JwtClaimNames.IAT, Objects::nonNull)
-            );
-
-
-            NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
-                    .withSecretKey(secretKey)
-                    .build();
-            jwtDecoder.setJwtValidator(validator);
-
-            Jwt jwt;
-
-            jwt = jwtDecoder.decode(token);
-
-            log.debug("JWT claims for current request: {}", jwt.getClaims());
-            return new JWTPrincipal(jwt,
-                    groupToRoleMapper,
-                    scopeToRoleMapper,
-                    rolesClaim,
-                    scopesClaim
-            );
-
-        } catch (InvalidJwtTokenException e) {
-            return null;
-        } catch (Exception e) {
-            log.warn("Issue processing JWT token", e);
-            return null;
+    @Override
+    protected boolean validConfiguration() {
+        if (StringUtils.isNotBlank(sharedSecret)) {
+            return true;
         }
+
+        log.warn("No JWT shared secret was set. JWT authentication is disabled.");
+        return false;
     }
 
 }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtSharedSecretPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtSharedSecretPrincipalProvider.java
@@ -22,12 +22,11 @@ public class JwtSharedSecretPrincipalProvider implements JwtPrincipalProvider {
     @Value("${jwt.shared-secret:}")
     private String sharedSecret;
 
-    @Value("${jwt.user-permissions-claim}")
-    private String userPermissionsClaim;
+    @Value("${jwt.roles-claim}")
+    private String rolesClaim;
 
     @Value("${jwt.scopes-claim}")
     private String scopesClaim;
-
 
     private final GroupToRoleMapper groupToRoleMapper;
     private final ScopeToRoleMapper scopeToRoleMapper;
@@ -77,113 +76,12 @@ public class JwtSharedSecretPrincipalProvider implements JwtPrincipalProvider {
             return null;
         }
 
-        IzgPrincipal principal = new JWTPrincipal();
-        principal.setName(jwt.getSubject());
-        principal.setOrganization(getClaimNestedAsString(jwt, "organization"));
-        principal.setValidFrom(Date.from(Objects.requireNonNull(jwt.getIssuedAt())));
-        principal.setValidTo(Date.from(Objects.requireNonNull(jwt.getExpiresAt())));
-        principal.setSerialNumber(jwt.getId());
-        // Nimbus doesn't like non-URI issuers, pull via raw claim
-        principal.setIssuer(getClaimNestedAsString(jwt, "iss"));
-        principal.setAudience(jwt.getAudience());
-        addScopes(getClaimNested(jwt, scopesClaim), principal);
-        addRolesFromScopes(getClaimNested(jwt, scopesClaim), principal);
-        addRolesFromGroups(getClaimNested(jwt, userPermissionsClaim), principal);
-        log.debug("JWT claims for current request: {}", jwt.getClaims());
-        return principal;
+        return new JWTPrincipal(jwt,
+                groupToRoleMapper,
+                scopeToRoleMapper,
+                rolesClaim,
+                scopesClaim
+        );
     }
 
-    private void addScopes(Object scopesClaim, IzgPrincipal principal) {
-        TreeSet<String> scopes = extractClaimList(scopesClaim);
-        principal.setScopes(scopes);
-    }
-
-    private void addRolesFromScopes(Object scopesClaim, IzgPrincipal principal) {
-        if (scopeToRoleMapper == null) {
-            log.debug("No scope to role mapper was set. Skipping scope to role mapping.");
-            return;
-        }
-        TreeSet<String> scopes = extractClaimList(scopesClaim);
-        principal
-                .getRoles()
-                .addAll(
-                        scopeToRoleMapper.mapScopesToRoles(scopes)
-                );
-    }
-
-    private TreeSet<String> extractClaimList(Object scopeList) {
-        // Oauth2 RFC (https://www.rfc-editor.org/rfc/rfc6749) states scopes
-        // should be "expressed as a list of space-
-        //   delimited, case-sensitive strings"
-        // However Okta seems to send back array of strings.
-        TreeSet<String> scopes = new TreeSet<>();
-        if (scopeList instanceof String scopeString) {
-            if (!StringUtils.isEmpty(scopeString)) {
-                Collections.addAll(scopes, scopeString.split(" "));
-            }
-        } else if (scopeList instanceof Collection<?> collection) {
-            collection.stream()
-                    .filter(String.class::isInstance)
-                    .map(String.class::cast)
-                    .forEach(scopes::add);
-        }
-        return scopes;
-    }
-
-    private void addRolesFromGroups(Object groupsClaim, IzgPrincipal principal) {
-        if (groupToRoleMapper == null) {
-            log.debug("No group to role mapper was set. Skipping group to role mapping.");
-            return;
-        }
-
-        TreeSet<String> groupsList = extractClaimList(groupsClaim);
-        if (groupsList.isEmpty()) {
-            return;
-        }
-
-        principal
-                .getRoles()
-                .addAll(
-                        groupToRoleMapper.mapGroupsToRoles(groupsList)
-                );
-    }
-
-    private String getClaimNestedAsString(Jwt jwt, String claimName) {
-        Object claimValue = getClaimNested(jwt, claimName);
-        return claimValue != null ? claimValue.toString() : null;
-    }
-
-    private Object getClaimNested(Jwt jwt, String claimPath) {
-        String[] claimPathParts = claimPath.split("\\.");
-        Object claim = jwt.getClaim(claimPathParts[0]);
-
-        if (claimPathParts.length > 1 && !(claim instanceof Map<?,?>)) {
-            /*
-             Catches situation where you have configured groups.access.
-             The initial pull of groups returns an array list.
-             Without this, we'd end up returning that pull from groups
-             as the claim Object, and ignore the fact that the user had
-             configured another level.
-             Seemed dangerous.
-            */
-            return null;
-        }
-
-        if (claim instanceof Map<?, ?> map && claimPathParts.length > 1) {
-            for (int i = 1; i < claimPathParts.length; i++) {
-                claim = map.get(claimPathParts[i]);
-                if (claim instanceof Map<?, ?>) {
-                    map = (Map<?, ?>) claim;
-                } else if (i < claimPathParts.length - 1) {
-                    /*
-                    Again, catches a situation where the user has configured groups.level1.level2 and at level1
-                    we have obtained a non-Map. So basically level2 didn't exist, but we don't want to return
-                    the value pulled from level1.
-                     */
-                    return null;
-                }
-            }
-        }
-        return claim;
-    }
 }

--- a/src/main/java/gov/cdc/izgateway/security/principal/JwtTokenExtractor.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/JwtTokenExtractor.java
@@ -1,0 +1,18 @@
+package gov.cdc.izgateway.security.principal;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenExtractor {
+    public String extractToken(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("No JWT token found in Authorization header");
+            throw new InvalidJwtTokenException("No valid JWT token in Authorization header");
+        }
+        return authHeader.substring(7);
+    }
+}

--- a/src/test/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProviderTest.java
+++ b/src/test/java/gov/cdc/izgateway/security/principal/AbstractJwtPrincipalProviderTest.java
@@ -1,0 +1,318 @@
+package gov.cdc.izgateway.security.principal;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class AbstractJwtPrincipalProviderTest {
+    private TestJwtPrincipalProvider jwtProvider;
+    private final String sharedSecret = "f7b3f3bd00e12434bbb155007498f857e93803c2c01f686253979c408dd28a91f999922aad3a8fa5cbd8bbbbb1f8ef9fbcddcb99cb44d9c7028c6904f306c4e6";
+    private final String jwtIssuer = "theIssuer";
+    private final String jwtSubject = "sampleSubject";
+    private final String jwtAudience = "theAudience";
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = new TestJwtPrincipalProvider();
+    }
+
+    @Test
+    void invalidSharedSecret() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, "87eaf799da3d3d8fe5165d8b25482afa27f9133256a9d887bc24f47b30160db47636219d61047b53d9552723426befa0b242a4d61ddccb53340950ad831110ab");
+
+        BadJwtException exception = assertThrows(BadJwtException.class, () -> getJwtFromToken(token));
+
+        assertEquals("An error occurred while attempting to decode the Jwt: Signed JWT rejected: Invalid signature",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void allTimestampsValid() throws Exception {
+
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void missingIat() throws Exception {
+
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void missingNbf() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void missingIatNbf() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertTrue(result.hasErrors());
+    }
+
+    @Test
+    void missingAllTimestampsValid() throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertTrue(result.hasErrors());
+    }
+
+    @Test
+    void expiredExp() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(-60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+
+        BadJwtException exception = assertThrows(BadJwtException.class, () -> getJwtFromToken(token));
+
+        assertEquals("An error occurred while attempting to decode the Jwt: expiresAt must be after issuedAt",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void futureIat() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now.plusSeconds(30)))
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        Jwt jwt = getJwtFromToken(token);
+
+        OAuth2TokenValidatorResult result = jwtProvider.createValidator().validate(jwt);
+
+        assertTrue(result.hasErrors());
+
+    }
+
+    @Test
+    void futureNbf() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now.plusSeconds(120)))
+                .expirationTime(Date.from(now.plusSeconds(360)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+
+        assertThrows(JwtValidationException.class, () -> getJwtFromToken(token));
+    }
+
+    @Test
+    void IatAfterExp() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now.plusSeconds(90)))
+                .notBeforeTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(60)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+        BadJwtException exception = assertThrows(BadJwtException.class, () -> getJwtFromToken(token));
+
+        assertEquals("An error occurred while attempting to decode the Jwt: expiresAt must be after issuedAt",
+                exception.getMessage()
+        );
+
+    }
+
+    @Test
+    void NbfAfterExp() throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(jwtIssuer)
+                .subject(jwtSubject)
+                .audience(jwtAudience)
+                .jwtID(java.util.UUID.randomUUID().toString())
+
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now.plusSeconds(360)))
+                .expirationTime(Date.from(now.plusSeconds(120)))
+
+                .build();
+
+        String token = createToken(claims, sharedSecret);
+
+        JwtValidationException exception = assertThrows(JwtValidationException.class, () -> getJwtFromToken(token));
+
+        assertTrue(exception.getMessage().contains("Jwt used before"));
+    }
+
+    private Jwt getJwtFromToken(String token) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(
+                new SecretKeySpec(sharedSecret.getBytes(), "HmacSHA256")
+        ).build();
+
+        return decoder.decode(token);
+    }
+
+    // Used to generate self-signed JWT using specified claims
+    private String createToken(JWTClaimsSet claims, String sharedSecret) throws Exception {
+        JWSSigner signer = new MACSigner(sharedSecret);
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader(JWSAlgorithm.HS256),
+                claims
+        );
+        signedJWT.sign(signer);
+        return signedJWT.serialize();
+    }
+
+    private static class TestJwtPrincipalProvider extends AbstractJwtPrincipalProvider {
+        TestJwtPrincipalProvider() {
+            super(null, null, mock(JwtTokenExtractor.class));
+        }
+
+        @Override
+        protected NimbusJwtDecoder createDecoder() {
+            return mock(NimbusJwtDecoder.class);
+        }
+
+        @Override
+        protected boolean validConfiguration() {
+            return true;
+        }
+    }
+}
+
+


### PR DESCRIPTION
- JWTPrincipal
  - Move code centrally that ultimately was being repeated between Jwks and Shared Secret implementations.
  - getClaimNested added to handle situations (like KeyCloak) where claims can be nested.  So one can configure something like realm_access.roles for situations like "realm_access":{"roles":["role1","role2","role3"]}
  - extractClaimList added to deal with difference in scopes claim.  RFC states should be space delimited list, however Okta (and others) return this is an array of strings.  
- AbstractJwtPrincipalProvider added for initial implement of JwtPrincipalProvider for shared code between Jwks and Shared Secret implementations.
  - Roles and Scopes claim name read from environment/configuration (scope vs scp for example).  
  - Add validator to reject JWT tokens where IAT/NBF/EXP are missing.
- JwtJwksPrincipalProvider and JwtSharedSecretPrincipalProvider now extend AbstractJwtPrincipalProvider to remove duplicate code
- JwtTokenExtractor added to centralize pulling bearer token from header.
- Add unit tests for JWT

Current timestamp scenarios tested documented here: https://izgateway.atlassian.net/wiki/spaces/IGDD/pages/163676161/JWT+Verification