### PR TITLE
IGDD-1923 Adding SecretHeaderFilter and tests

### DIFF
--- a/src/main/java/gov/cdc/izgateway/security/filter/IpAddressFilter.java
+++ b/src/main/java/gov/cdc/izgateway/security/filter/IpAddressFilter.java
@@ -1,5 +1,7 @@
 package gov.cdc.izgateway.security.filter;
 
+import gov.cdc.izgateway.logging.RequestContext;
+import gov.cdc.izgateway.logging.markers.Markers2;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import jakarta.servlet.*;
@@ -19,7 +21,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class IpAddressFilter implements Filter {
     private List<IPAddress> allowedSubnets = Collections.emptyList();
     private final boolean ipFilterEnabled;
@@ -69,7 +71,7 @@ public class IpAddressFilter implements Filter {
 
         } catch (Exception e) {
             // We were unable to parse the IP address, block access
-            log.warn("Unable to parse/verify IP: {}. Error: {}", clientIp, e.getMessage());
+            log.error(Markers2.append(RequestContext.getSourceInfo()), "Unable to parse/verify IP: {}. Error: {}", clientIp, e.getMessage());
             HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
             httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return;
@@ -78,7 +80,7 @@ public class IpAddressFilter implements Filter {
         if (allowed) {
             filterChain.doFilter(servletRequest, servletResponse);
         } else {
-            log.warn("Access denied for IP: {}. Not in any configured allowed CIDR.", clientIp);
+            log.error(Markers2.append(RequestContext.getSourceInfo()), "Access denied for IP: {}. Not in any configured allowed CIDR.", clientIp);
             HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
             httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
         }

--- a/src/main/java/gov/cdc/izgateway/security/filter/SecretHeaderFilter.java
+++ b/src/main/java/gov/cdc/izgateway/security/filter/SecretHeaderFilter.java
@@ -1,5 +1,7 @@
 package gov.cdc.izgateway.security.filter;
 
+import gov.cdc.izgateway.logging.RequestContext;
+import gov.cdc.izgateway.logging.markers.Markers2;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
-
+import gov.cdc.izgateway.security.AccessControlValve;
 import java.io.IOException;
 
 /**
@@ -20,7 +22,7 @@ import java.io.IOException;
  */
 @Slf4j
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class SecretHeaderFilter implements Filter {
     private final boolean headerFilterEnabled;
     private final String headerFilterKey;
@@ -46,7 +48,7 @@ public class SecretHeaderFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        if (!headerFilterEnabled) {
+        if (!headerFilterEnabled || AccessControlValve.isLocalHost(servletRequest.getRemoteAddr())) {
             filterChain.doFilter(servletRequest, servletResponse);
             return;
         }
@@ -57,7 +59,7 @@ public class SecretHeaderFilter implements Filter {
         String headerValue = request.getHeader(headerFilterKey);
 
         if (headerValue == null || !headerValue.equals(headerFilterValue)) {
-            log.warn("Request does not contain the secret header, rejecting request");
+            log.error(Markers2.append(RequestContext.getSourceInfo()), "Request does not contain the secret header, rejecting request.");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }

--- a/src/main/java/gov/cdc/izgateway/security/filter/SecretHeaderFilter.java
+++ b/src/main/java/gov/cdc/izgateway/security/filter/SecretHeaderFilter.java
@@ -1,0 +1,68 @@
+package gov.cdc.izgateway.security.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * SecretHeaderFilter is a servlet filter that checks for a specific header in incoming requests.
+ * This is used to ensure that only requests from internal services (like ALB or WAF) are allowed to pass through.
+ * It is disabled by default, but can be enabled via the settings in the constructor.
+ * If the filter is enabled but the key or value is missing, an IllegalStateException is thrown.
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SecretHeaderFilter implements Filter {
+    private final boolean headerFilterEnabled;
+    private final String headerFilterKey;
+    private final String headerFilterValue;
+
+    public SecretHeaderFilter(
+            @Value("${hub.security.secret-header-filter.enabled:false}") boolean headerFilterEnabled,
+            @Value("${hub.security.secret-header-filter.key:}") String headerFilterKey,
+            @Value("${hub.security.secret-header-filter.value:}") String headerFilterValue
+    ) {
+        this.headerFilterEnabled = headerFilterEnabled;
+        this.headerFilterKey = headerFilterKey;
+        this.headerFilterValue = headerFilterValue;
+
+        if (this.headerFilterEnabled) {
+            if (StringUtils.isEmpty(this.headerFilterKey) || StringUtils.isEmpty(this.headerFilterValue)) {
+                throw new IllegalStateException("Secret header filter is enabled, but the header key or value is not set.");
+            }
+        } else {
+            log.warn("Secret header filter not enabled. Requests will not be filtered.");
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        if (!headerFilterEnabled) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        // Check if the request is from an internal service (ALB, WAF) by checking the header
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        String headerValue = request.getHeader(headerFilterKey);
+
+        if (headerValue == null || !headerValue.equals(headerFilterValue)) {
+            log.warn("Request does not contain the secret header, rejecting request");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // Continue the filter chain
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/src/test/java/gov/cdc/izgateway/security/filter/SecretHeaderFilterTests.java
+++ b/src/test/java/gov/cdc/izgateway/security/filter/SecretHeaderFilterTests.java
@@ -1,0 +1,86 @@
+// File: src/test/java/gov/cdc/izgateway/security/filter/SecretHeaderFilterTests.java
+
+package gov.cdc.izgateway.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class SecretHeaderFilterTests {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private SecretHeaderFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        // Initialize the filter with test values
+        filter = new SecretHeaderFilter(true, "x-alb-secret", "secret-value");
+    }
+
+    @Test
+    void testFilterDisabled() throws IOException, ServletException {
+        // Initialize the filter with disabled state
+        filter = new SecretHeaderFilter(false, "", "");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test
+    void testFilterEnabledWithoutKeyOrValue() {
+        // Expect IllegalStateException when filter is enabled but key or value is missing
+        assertThrows(IllegalStateException.class, () -> new SecretHeaderFilter(true, "", ""));
+    }
+
+    @Test
+    void testRequestWithoutHeader() throws IOException, ServletException {
+        when(request.getHeader("x-alb-secret")).thenReturn(null);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(any(), any());
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void testRequestWithInvalidHeader() throws IOException, ServletException {
+        when(request.getHeader("x-alb-secret")).thenReturn("invalid-value");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(any(), any());
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void testRequestWithValidHeader() throws IOException, ServletException {
+        when(request.getHeader("x-alb-secret")).thenReturn("secret-value");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(response, never()).setStatus(anyInt());
+    }
+}


### PR DESCRIPTION
Adding SecretHeaderFilter and tests that will allow a secret header to be added from the WAF/ALB to prove to the Hub service that the call came from the ALB. This is to add a security layer to our security model.

It is disabled by default.

The Hub service will fail to start if the filter is enabled and the required configurations are not set.

Configs:
hub.security.secret-header-filter.enabled:false
hub.security.secret-header-filter.key:
hub.security.secret-header-filter.value:
