### PR TITLE
Fix for IGDD-1968 GET /HubRequestService?xsd=cdc-iis.xsd does not work

### DIFF
--- a/src/main/java/gov/cdc/izgateway/soap/SoapControllerBase.java
+++ b/src/main/java/gov/cdc/izgateway/soap/SoapControllerBase.java
@@ -344,10 +344,11 @@ public abstract class SoapControllerBase {
 			wsdl = ObjectUtils.defaultIfNull(wsdl, wsdl2);
 			if (wsdl == null && StringUtils.isEmpty(xsd)) {
 				throw new UnsupportedOperationFault("At least one of the WSDL or xsd parameters must be present", null);
-			} else if (xsd != null && XSD_FILES.contains(xsd)) {
+			} else if (xsd != null && !XSD_FILES.contains(xsd)) {
 				throw new UnsupportedOperationFault("Schema " + xsd + " unknown", null);
 			}
-			String resourceName = wsdl != null ? "/soap/wsdl/" + getWsdl() : ("/soap/schema" + xsd);
+			
+			String resourceName = wsdl != null ? "/soap/wsdl/" + getWsdl() : ("/soap/schema/" + xsd);
 			return logEndOfRequest(() -> getResource(resourceName));
 		} catch (Fault ex) {
 			fault = ex;


### PR DESCRIPTION
Added two characters to fix this bug, a / to separate path correctly, and a ! to fix logic inversion.