### PR TITLE
Upgrade lang3 to 3.18.0, spring-doc to 2.8.9 (for DOMPurify CVE)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>[3.18.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -173,12 +174,12 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <version>2.8.3</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.8.3</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
Updates to CORE for lang3 and spring-doc CVEs in xform service.