### PR TITLE
Add bom for spring-framework and netty for owasp scan findings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb-enhanced</artifactId>
-      <version>2.31.54</version>
+      <version>2.32.23</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.6</version>
+    <version>3.5.4</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>
@@ -37,6 +37,29 @@
     <project.java.package>${project.groupId}</project.java.package>
     <mysql.version>9.3.0</mysql.version>
   </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>6.2.10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.4.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>10.4.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>ca.uhn.hapi</groupId>
@@ -250,7 +273,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb-enhanced</artifactId>
-      <version>2.32.23</version>
+      <version>2.32.24</version>
     </dependency>
   </dependencies>
   <build>
@@ -349,7 +372,7 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <!-- 9.0 line uses NVD API and requires a key, which has flakey response right now -->
-        <version>8.4.3</version>
+        <version>12.1.1</version>
         <configuration>
           <!--nvdApiKey>${env.NVDAPIKEY}</nvdApiKey-->
           <formats>


### PR DESCRIPTION
Bump spring to latest.  Add bom for spring-framework so the latest is pulled because of vulnerability.  Add bom for netty, even if on latest dynamodb-enhanced owasp picks up issue.  Add nimbus to handle medium vulnerability, similar to how we've done in hub and transform.