### PR TITLE
IGDD-2224 Bug fix for CDC WSDL

### DIFF
--- a/src/main/java/gov/cdc/izgateway/soap/message/SoapMessage.java
+++ b/src/main/java/gov/cdc/izgateway/soap/message/SoapMessage.java
@@ -165,14 +165,15 @@ public class SoapMessage implements Serializable {
 	 * @return The 2011 name for the request
 	 */
 	private String to2011name(String name) {
+        if (this instanceof Response && responseNames.contains(name)) {
+            return "return";
+        }
+
 		String newName = nameMap.get(name);
 		if (newName != null) {
 			return newName;
 		}
-		if (this instanceof Response && responseNames.contains(name)) {
-            nameMap.put(name, "return");
-			return "return";
-		}
+
         StringBuilder b = new StringBuilder(name);
 		// Lowercase the initial character
 		b.setCharAt(0, Character.toLowerCase(b.charAt(0)));


### PR DESCRIPTION
This bug appears to be related to the fact that the nameMap holds both request and response names.  This became problematic because Hl7Message is used in both Requests and Responses.  The response needs to be handled special for the CDC WSDL (2011 wsdl), if it is a response and the name is Hl7Message, we need to change it to 'return' but not store it in the nameMap.  This logic is now moved to the beginning of the method as the first check in the strategy.  

This explains the weird behavior we saw in the preprod environment in APHL (if that method received a request message first, the Hl7Message name got added to the map first resulting in subsequent response messages being set to 'hl7Message' instead of 'return').