### PR TITLE
Improve logging condition check for non-null transaction data

### DIFF
--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @Component("valveLogging")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class LoggingValve extends LoggingValveBase implements EventCreator {
-	private static final String DEV_SERVICE_PPREFIX = "/dev/";
+	private static final String DEV_SERVICE_PREFIX = "/dev/";
 	private static final String IIS_CDC_SERVICE = "/izgw";
 	private static final String IIS_HUB_SERVICE = "/IISHubService";
 	private static final String REST_ADS = "/rest/ads";
@@ -85,7 +85,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
                 RequestContext.disableTransactionDataLogging();
                 break;
             default:
-                if (request.getRequestURI().startsWith(IIS_HUB_SERVICE) || request.getRequestURI().startsWith(DEV_SERVICE_PPREFIX)) {
+                if (request.getRequestURI().startsWith(IIS_HUB_SERVICE) || request.getRequestURI().startsWith(DEV_SERVICE_PREFIX)) {
                     // Any HTTP URI like this denotes a problem with how the request was formulated.
                     log.error("Unexpected HTTP Error {} from SOAP Request", response.getStatus());
                 }
@@ -96,13 +96,6 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
             if (messageInfo != null) {
                 messageInfo.setHttpHeaders(getHeaders(response));
             }
-            log.info(Markers2.append("transactionData", t), 
-            	"What {} be logged and {} is: {}", 
-            	isLoggingDisabled ? "will NOT" : "will",
-            	isLogged(request.getRequestURI()) ? "should be" : "should NOT be",
-            	t.getMessage()
-            );
-
         } finally {
             if (monitored) {
                 adsRequests.remove(request);
@@ -147,7 +140,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
 	}
 
 	protected boolean isLogged(String requestURI) {
-		return Strings.CS.startsWithAny(requestURI, REST_ADS, IIS_HUB_SERVICE, IIS_CDC_SERVICE, DEV_SERVICE_PPREFIX);
+		return Strings.CS.startsWithAny(requestURI, REST_ADS, IIS_HUB_SERVICE, IIS_CDC_SERVICE, DEV_SERVICE_PREFIX);
 	}
 
 	@Override

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
@@ -43,7 +43,6 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
 	private static final String IIS_CDC_SERVICE = "/izgw";
 	private static final String IIS_HUB_SERVICE = "/IISHubService";
 	private static final String REST_ADS = "/rest/ads";
-	private final PrincipalService principalService;
 	@SuppressWarnings("unused")
 	private ScheduledFuture<?> adsMonitor =
     	Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "ADS Monitor"))
@@ -51,7 +50,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
     private static final ConcurrentHashMap<Request, String> adsRequests = new ConcurrentHashMap<>();
     @Autowired
     public LoggingValve(PrincipalService principalService) {
-        this.principalService = principalService;
+        super(principalService);
     }
 
     @Override

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
@@ -68,7 +68,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
             
             TransactionData t = RequestContext.getTransactionData();
             
-            if (RequestContext.getTransactionData() != null && !RequestContext.isLoggingDisabled()) {
+            if (t != null && !RequestContext.isLoggingDisabled()) {
                 HealthService.incrementVolumes(t.getHasProcessError());
             }
 

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValve.java
@@ -39,8 +39,11 @@ import java.util.concurrent.TimeUnit;
 @Component("valveLogging")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class LoggingValve extends LoggingValveBase implements EventCreator {
+	private static final String DEV_SERVICE_PPREFIX = "/dev/";
+	private static final String IIS_CDC_SERVICE = "/izgw";
 	private static final String IIS_HUB_SERVICE = "/IISHubService";
 	private static final String REST_ADS = "/rest/ads";
+	private final PrincipalService principalService;
 	@SuppressWarnings("unused")
 	private ScheduledFuture<?> adsMonitor =
     	Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "ADS Monitor"))
@@ -67,8 +70,8 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
             this.getNext().invoke(request, response);
             
             TransactionData t = RequestContext.getTransactionData();
-            
-            if (t != null && !RequestContext.isLoggingDisabled()) {
+            boolean isLoggingDisabled = RequestContext.isLoggingDisabled();
+            if (t != null && !isLoggingDisabled) {
                 HealthService.incrementVolumes(t.getHasProcessError());
             }
 
@@ -83,7 +86,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
                 RequestContext.disableTransactionDataLogging();
                 break;
             default:
-                if (request.getRequestURI().startsWith(IIS_HUB_SERVICE) || request.getRequestURI().startsWith("/dev/")) {
+                if (request.getRequestURI().startsWith(IIS_HUB_SERVICE) || request.getRequestURI().startsWith(DEV_SERVICE_PPREFIX)) {
                     // Any HTTP URI like this denotes a problem with how the request was formulated.
                     log.error("Unexpected HTTP Error {} from SOAP Request", response.getStatus());
                 }
@@ -94,6 +97,12 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
             if (messageInfo != null) {
                 messageInfo.setHttpHeaders(getHeaders(response));
             }
+            log.info(Markers2.append("transactionData", t), 
+            	"What {} be logged and {} is: {}", 
+            	isLoggingDisabled ? "will NOT" : "will",
+            	isLogged(request.getRequestURI()) ? "should be" : "should NOT be",
+            	t.getMessage()
+            );
 
         } finally {
             if (monitored) {
@@ -139,7 +148,7 @@ public class LoggingValve extends LoggingValveBase implements EventCreator {
 	}
 
 	protected boolean isLogged(String requestURI) {
-    	return requestURI.startsWith(REST_ADS) || requestURI.startsWith(IIS_HUB_SERVICE) || requestURI.startsWith("/izgw") || requestURI.startsWith("/dev/");
+		return Strings.CS.startsWithAny(requestURI, REST_ADS, IIS_HUB_SERVICE, IIS_CDC_SERVICE, DEV_SERVICE_PPREFIX);
 	}
 
 	@Override

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
@@ -83,14 +83,14 @@ public abstract class LoggingValveBase extends ValveBase implements EventCreator
     /** 
 	 * Default constructor for cases where no principal service is needed.
 	 */
-    public LoggingValveBase() {
+    protected LoggingValveBase() {
 		this.principalService = null;
 	}
 
     /** 
 	 * Constructor with principal service.
 	 */
-    public LoggingValveBase(PrincipalService principalService) {
+    protected LoggingValveBase(PrincipalService principalService) {
 		this.principalService = principalService;
 	}
 

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
@@ -80,7 +80,21 @@ public abstract class LoggingValveBase extends ValveBase implements EventCreator
         }
     }
 
-    protected static String convertSize(long sizeBytes) {
+    /** 
+	 * Default constructor for cases where no principal service is needed.
+	 */
+    public LoggingValveBase() {
+		this.principalService = null;
+	}
+
+    /** 
+	 * Constructor with principal service.
+	 */
+    public LoggingValveBase(PrincipalService principalService) {
+		this.principalService = principalService;
+	}
+
+	protected static String convertSize(long sizeBytes) {
     	if (sizeBytes <= 0) {
     		return "0b";
     	}
@@ -100,7 +114,7 @@ public abstract class LoggingValveBase extends ValveBase implements EventCreator
         SourceInfo source = setSourceInfoValues(req, t);
 
         // Set RequestContext values.
-        IzgPrincipal p = principalService.getPrincipal(req);
+        IzgPrincipal p = getPrincipal(req);
         RequestContext.setPrincipal(p);
         RequestContext.setTransactionData(t);
         RequestContext.setHttpHeaders(getHeaders(req));
@@ -132,7 +146,16 @@ public abstract class LoggingValveBase extends ValveBase implements EventCreator
         }
     }
 
-    protected abstract void clearContext();
+    /** 
+     * If there is a principal service, get the principal for the request.
+     * @param req	The request to get the principal for.
+     * @return The principal for the request, or null if no principal service is configured.
+     */
+    private IzgPrincipal getPrincipal(Request req) {
+		return principalService == null ? null : principalService.getPrincipal(req);
+	}
+
+	protected abstract void clearContext();
 
 	protected abstract TransactionData createTransactionData(Request req);
 

--- a/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
+++ b/src/main/java/gov/cdc/izgateway/logging/LoggingValveBase.java
@@ -123,7 +123,7 @@ public abstract class LoggingValveBase extends ValveBase implements EventCreator
             log.error(Markers2.append(err), "Error during invocation", err);
         } finally {
             // Log first, then clean up MDC!
-            if (RequestContext.getTransactionData() != null && !RequestContext.isLoggingDisabled()) {
+            if (t != null && !RequestContext.isLoggingDisabled()) {
                 t.logIt();
             }
             RequestContext.clear();

--- a/src/main/java/gov/cdc/izgateway/logging/event/TransactionData.java
+++ b/src/main/java/gov/cdc/izgateway/logging/event/TransactionData.java
@@ -693,12 +693,18 @@ public class TransactionData {
         );
     }
 
+    /**
+     * Compute the transaction times based on the start time and elapsed times.
+     */
     public void computeTransactionTimes() {
         setElapsedTimeTotal(System.currentTimeMillis() - getStartTime());
         setElapsedTimeProcessing(getElapsedTimeTotal() - getElapsedTimeIIS());
         setWriteTimeIIS(getElapsedTimeIIS() - getReadTimeIIS());
     }
 
+    /**
+     * Log this transaction data.
+     */
     public void logIt() {
         computeTransactionTimes();
         log.info(Markers2.append("transactionData", this), "{}", getMessage());


### PR DESCRIPTION
Minor cleanup in logging valve.  Reuse local variable t instead of calling RequestContext.getTransactionData() each time.