### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -34,19 +34,19 @@ jobs:
     steps:
       - name: Generate Release Automation App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.RELEASE_AUTOMATION_APP_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # Full history for release notes generation
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -56,7 +56,7 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.0
 
@@ -386,21 +386,21 @@ jobs:
             --disableAssembly      
 
       - name: Upload dependency check report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-report
           path: ./target/site/dependency-check-report.html
           if-no-files-found: ignore
 
       - name: Publish Site (Current)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           publish_dir: ./target/site
           destination_dir: current
 
       - name: Publish Site (Versioned)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           publish_dir: ./target/site
@@ -543,7 +543,7 @@ jobs:
           echo "GitHub Release body created"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ inputs.release-version }}
           name: IZ Gateway Core v${{ inputs.release-version }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,20 +27,20 @@ jobs:
     steps:
     
     - name: Checkout the software  
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # Necessary to enable push to protected branch
       with:
         ssh-key: ${{secrets.ACTIONS_KEY}}
         
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
         
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.0
         
@@ -187,14 +187,14 @@ jobs:
             -Dimage.tag=$IMAGE_BRANCH_TAG 
             
     - name: Upload build environment as artifact for failed build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: build-failure
         path: .
 
     - name: Upload dependency check log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ ! env.SKIP_DEPENDENCY_CHECK }}
       with:
         name: DependencyCheck
@@ -203,7 +203,7 @@ jobs:
     - name: Publish Site (Develop)
       # Publish to /develop/ for: push to develop, PRs targeting develop, scheduled runs, manual dispatch
       if: github.ref == 'refs/heads/develop' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/site
@@ -215,14 +215,14 @@ jobs:
     # This step should only be done on PUSH to main
     if: github.ref == 'refs/heads/testmain' || github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       # Necessary to enable push to protected branch
       with:
         ssh-key: ${{secrets.ACTIONS_KEY}}
 
     - name: Create GitHub Release
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -235,7 +235,7 @@ jobs:
           ./docs/release/*.md
 
     - name: Upload release documentation as artifact for failed release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: release-failure


### PR DESCRIPTION
- Updated all workflow actions to their latest stable Node.js 24 compatible versions (node20 deprecated, forced to node24 June 2 2026)
- Added .github/dependabot.yml to keep action versions up-to-date automatically going forward (weekly, major versions only)
