### PR TITLE
IGDD-2075 Add OCSP revocation check for ALB-forwarded client certificates.

### DIFF
--- a/src/main/java/gov/cdc/izgateway/security/TrustManagerProvider.java
+++ b/src/main/java/gov/cdc/izgateway/security/TrustManagerProvider.java
@@ -14,6 +14,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
 import java.util.ServiceConfigurationError;
 
 /**
@@ -39,10 +43,13 @@ public class TrustManagerProvider {
     @Getter
     private X509TrustManager serverTrustManager;
 
+    @Getter
+    private KeyStore trustStore;
+
     @PostConstruct
     private void initializeTrustManager() {
         try {
-            KeyStore trustStore = KeyStore.getInstance(trustStoreType, trustStoreProvider);
+            this.trustStore = KeyStore.getInstance(trustStoreType, trustStoreProvider);
 
             try (FileInputStream fis = new FileInputStream(trustStorePath)) {
                 trustStore.load(fis, trustStorePassword.toCharArray());
@@ -62,5 +69,27 @@ public class TrustManagerProvider {
             throw new ServiceConfigurationError(e.getMessage(), e);
         }
         throw new ServiceConfigurationError("No ServerTrustManager could be found.");
+    }
+
+    /**
+     * Finds the issuer certificate for the given leaf certificate by matching its issuer DN
+     * against the subject DN of each entry in the trust store.
+     * Returns null if no match is found — callers should skip OCSP in that case.
+     */
+    public X509Certificate findIssuerCert(X509Certificate cert) {
+        String issuerDN = cert.getIssuerX500Principal().getName();
+        try {
+            Enumeration<String> aliases = trustStore.aliases();
+            while (aliases.hasMoreElements()) {
+                Certificate candidate = trustStore.getCertificate(aliases.nextElement());
+                if (candidate instanceof X509Certificate x509
+                        && x509.getSubjectX500Principal().getName().equals(issuerDN)) {
+                    return x509;
+                }
+            }
+        } catch (KeyStoreException e) {
+            log.warn("Error looking up issuer cert for {}", issuerDN, e);
+        }
+        return null;
     }
 }

--- a/src/main/java/gov/cdc/izgateway/security/ocsp/RevocationChecker.java
+++ b/src/main/java/gov/cdc/izgateway/security/ocsp/RevocationChecker.java
@@ -123,9 +123,12 @@ public class RevocationChecker {
 				// It was previous checked, and sufficient time hasn't passed
 				return;
 			}
+		} catch (CertPathValidatorException cpve) {
+			// Explicit revocation — must not be swallowed. Re-throw so the caller rejects the cert.
+			throw cpve;
 		} catch (Exception e) {
 			log.error(Markers2.append(e), "Error retrieving certificate status for {}", X500Utils.getCommonName(cert));
-			// DB Access failure should NOT block certificate validation
+			// DB access failure should NOT block certificate validation — fail open.
 			return;
 		}
 

--- a/src/main/java/gov/cdc/izgateway/security/principal/CertificatePrincipalProviderImpl.java
+++ b/src/main/java/gov/cdc/izgateway/security/principal/CertificatePrincipalProviderImpl.java
@@ -2,6 +2,7 @@ package gov.cdc.izgateway.security.principal;
 
 import gov.cdc.izgateway.principal.provider.CertificatePrincipalProvider;
 import gov.cdc.izgateway.security.*;
+import gov.cdc.izgateway.security.ocsp.RevocationChecker;
 import gov.cdc.izgateway.utils.X500Utils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -25,10 +26,12 @@ public class CertificatePrincipalProviderImpl implements CertificatePrincipalPro
     private String certHeaderKey;
 
     private final CertificateValidator validator;
+    private final TrustManagerProvider trustManagerProvider;
 
     @Autowired
     public CertificatePrincipalProviderImpl(TrustManagerProvider provider) {
         this.validator = new CertificateValidator(provider.getServerTrustManager());
+        this.trustManagerProvider = provider;
     }
 
     @Override
@@ -64,8 +67,12 @@ public class CertificatePrincipalProviderImpl implements CertificatePrincipalPro
 
         try {
             cert = CertificateProcessor.processCertificateFromHeader(certHeader);
-        	log.debug("Certificate found in {}", certHeaderKey);
-            return validator.isValid(cert) ? cert : null;
+            log.debug("Certificate found in {}", certHeaderKey);
+            if (!validator.isValid(cert)) {
+                return null;
+            }
+            checkRevocation(cert);
+            return cert;
         } catch (CertificateException e) {
             log.error("Failed to process certificate from header {}", certHeader, e);
             return null;
@@ -84,6 +91,30 @@ public class CertificatePrincipalProviderImpl implements CertificatePrincipalPro
     private X509Certificate getCertificateFromAttribute(HttpServletRequest request) {
         X509Certificate[] certs = (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
         return (certs != null && certs.length > 0) ? certs[0] : null;
+    }
+
+    /**
+     * Checks OCSP revocation status for a cert received via the ALB header.
+     * Resolves the issuer from the trust store; skips the check with a warning if the issuer
+     * is not found (certs without a known issuer in the trust store cannot be OCSP-checked).
+     * Throws CertificateException if the cert is confirmed revoked.
+     */
+    private void checkRevocation(X509Certificate cert) throws CertificateException {
+        RevocationChecker checker = RevocationChecker.getInstance();
+        if (checker == null) {
+            return;
+        }
+        X509Certificate issuer = trustManagerProvider.findIssuerCert(cert);
+        if (issuer == null) {
+            log.warn("Issuer cert not found in trust store for {}, skipping OCSP check",
+                    X500Utils.getCommonName(cert));
+            return;
+        }
+        try {
+            checker.check(RevocationChecker.SslLocation.CLIENT, cert, issuer);
+        } catch (CertPathValidatorException e) {
+            throw new CertificateException("Certificate revoked: " + e.getMessage(), e);
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes a gap that was found for revocation checks.