### PR TITLE
IGDD-3056: Fix TransactionData logging for WSDL GET requests

### DIFF
--- a/src/main/java/gov/cdc/izgateway/logging/event/TransactionData.java
+++ b/src/main/java/gov/cdc/izgateway/logging/event/TransactionData.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import gov.cdc.izgateway.common.Constants;
 import gov.cdc.izgateway.configuration.AppProperties;
+import gov.cdc.izgateway.logging.LoggingValveBase;
 import gov.cdc.izgateway.logging.info.DestinationInfo;
 import gov.cdc.izgateway.logging.info.MessageInfo.RequestInfo;
 import gov.cdc.izgateway.logging.info.MessageInfo.ResponseInfo;
@@ -36,6 +37,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
 
 @Slf4j
 @JsonPropertyOrder(value = {
@@ -674,6 +676,14 @@ public class TransactionData {
     @JsonIgnore
     public String getMessage() {
         String unknown = "**unknown**";
+        if ("GET".equals(MDC.get(LoggingValveBase.METHOD))) {
+            // A GET on a SOAP endpoint is a WSDL/schema retrieval, not a transaction.
+            // It has no destination and no message type, so log a short, distinct message.
+            return String.format("WSDL/schema retrieval from %s at %s",
+                    source == null ? unknown : source.getName(),
+                    source == null ? unknown : source.getIpAddress()
+            );
+        }
         return String.format("%sTransaction %s(%s) containing %s(%s) "
                         + "from %s at %s "
                         + "to %s at %s(%s) "
@@ -707,6 +717,12 @@ public class TransactionData {
      */
     public void logIt() {
         computeTransactionTimes();
-        log.info(Markers2.append("transactionData", this), "{}", getMessage());
+        if ("GET".equals(MDC.get(LoggingValveBase.METHOD))) {
+            // WSDL/schema retrievals are performed on every SOAP invocation by frameworks
+            // like STC and Docket; log them at debug so they do not pollute the INFO stream.
+            log.debug(Markers2.append("transactionData", this), "{}", getMessage());
+        } else {
+            log.info(Markers2.append("transactionData", this), "{}", getMessage());
+        }
     }
 }

--- a/src/test/java/gov/cdc/izgateway/logging/event/TransactionDataTest.java
+++ b/src/test/java/gov/cdc/izgateway/logging/event/TransactionDataTest.java
@@ -3,8 +3,10 @@ package gov.cdc.izgateway.logging.event;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,11 +27,29 @@ import gov.cdc.izgateway.logging.LoggingValveBase;
  */
 class TransactionDataTest {
 
+    private static AppProperties previousInstance;
+
     @BeforeAll
-    static void initAppProperties() {
-        // TransactionData's constructor reads AppProperties.isProduction(); the constructor
-        // registers itself as the static instance, which is all this test needs.
-        new AppProperties();
+    static void initAppProperties() throws Exception {
+        // TransactionData's constructor reads AppProperties.isProduction(). Instantiating
+        // AppProperties registers itself as the global static singleton, so capture whatever
+        // instance was there first and restore it in @AfterAll to avoid making other tests
+        // (e.g. Spring tests relying on @Value-injected AppProperties) order-dependent.
+        previousInstance = AppProperties.getInstance();
+
+        // When constructed outside Spring, serverMode is never injected and the effective mode
+        // is incidental. Force a deterministic "prod" mode so these tests do not depend on it.
+        AppProperties props = new AppProperties();
+        Field serverMode = AppProperties.class.getDeclaredField("serverMode");
+        serverMode.setAccessible(true);
+        serverMode.set(props, AppProperties.PROD_MODE_VALUE);
+    }
+
+    @AfterAll
+    static void restoreAppProperties() throws Exception {
+        Field instance = AppProperties.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, previousInstance);
     }
 
     @AfterEach

--- a/src/test/java/gov/cdc/izgateway/logging/event/TransactionDataTest.java
+++ b/src/test/java/gov/cdc/izgateway/logging/event/TransactionDataTest.java
@@ -1,0 +1,98 @@
+package gov.cdc.izgateway.logging.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import gov.cdc.izgateway.configuration.AppProperties;
+import gov.cdc.izgateway.logging.LoggingValveBase;
+
+/**
+ * Verifies the WSDL/schema (HTTP GET) special-casing added to {@link TransactionData}.
+ * A GET on a SOAP endpoint is a WSDL/schema retrieval, not a transaction, so it must
+ * produce a distinct message and be logged at DEBUG rather than INFO.
+ */
+class TransactionDataTest {
+
+    @BeforeAll
+    static void initAppProperties() {
+        // TransactionData's constructor reads AppProperties.isProduction(); the constructor
+        // registers itself as the static instance, which is all this test needs.
+        new AppProperties();
+    }
+
+    @AfterEach
+    void clearMdc() {
+        MDC.remove(LoggingValveBase.METHOD);
+    }
+
+    private TransactionData wsdlSource() {
+        TransactionData t = new TransactionData();
+        t.getSource().setCommonName("DocketClosed");
+        t.getSource().setIpAddress("10.1.2.3");
+        return t;
+    }
+
+    @Test
+    void getMessageForGetProducesWsdlRetrievalMessage() {
+        MDC.put(LoggingValveBase.METHOD, "GET");
+        TransactionData t = wsdlSource();
+        assertEquals("WSDL/schema retrieval from DocketClosed at 10.1.2.3", t.getMessage());
+    }
+
+    @Test
+    void getMessageForPostProducesTransactionMessage() {
+        MDC.put(LoggingValveBase.METHOD, "POST");
+        TransactionData t = wsdlSource();
+        String message = t.getMessage();
+        assertTrue(message.startsWith("Transaction "),
+                "POST must keep the standard transaction message, was: " + message);
+    }
+
+    @Test
+    void getMessageWithNoMethodProducesTransactionMessage() {
+        // No MDC method set (e.g. non-HTTP context) must behave like the pre-existing default.
+        TransactionData t = wsdlSource();
+        assertTrue(t.getMessage().startsWith("Transaction "));
+    }
+
+    @Test
+    void logItForGetLogsAtDebug() {
+        assertLogLevel("GET", Level.DEBUG);
+    }
+
+    @Test
+    void logItForPostLogsAtInfo() {
+        assertLogLevel("POST", Level.INFO);
+    }
+
+    private void assertLogLevel(String method, Level expected) {
+        Logger logger = (Logger) LoggerFactory.getLogger(TransactionData.class);
+        Level originalLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(Level.DEBUG); // ensure DEBUG events are not filtered out before capture
+        logger.addAppender(appender);
+        try {
+            MDC.put(LoggingValveBase.METHOD, method);
+            wsdlSource().logIt();
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(originalLevel);
+        }
+        List<ILoggingEvent> events = appender.list;
+        assertEquals(1, events.size(), "expected exactly one log event");
+        assertEquals(expected, events.get(0).getLevel());
+    }
+}


### PR DESCRIPTION
WSDL/schema retrievals arrive as HTTP GET on the SOAP endpoint (getWsdlOrXsd) and are not transactions: they have no destination and no message type. Previously messageType stayed at its INVALID_REQUEST sentinel and every GET was logged at INFO with the full transaction format, surfacing as spurious "Invalid Request" noise (IZHD-7215). SOAP frameworks used by STC and Docket fetch the WSDL on every call, so this happens on each invocation.

TransactionData now detects GET via the "method" MDC value set by LoggingValveBase.setMdcValues():
- getMessage() emits a short "WSDL/schema retrieval from <source> at <ip>" message for GET, with no destination or succeeded/failed clause; POST and all other methods keep the existing format.
- logIt() logs GET at DEBUG so WSDL retrievals no longer pollute the INFO stream; POST continues to log at INFO.

Adds TransactionDataTest covering both message variants and the GET->DEBUG / POST->INFO log-level routing.